### PR TITLE
deletePermissions updated

### DIFF
--- a/drive-permission-manager/src/types.ts
+++ b/drive-permission-manager/src/types.ts
@@ -26,3 +26,4 @@ export type User = {
 export type Role = "owner" | "organizer" | "fileOrganizer" | "writer" | "commenter" | "reader";
 export type GranteeType = "user" | "group" | "domain" | "anyone"
 export type GetPermissionsOptions = {fileId: string} | {emailAddress: string}
+export type DeletePermissionsOptions = {emails?: string[], permissionIds?: string[]}

--- a/webserver/index.js
+++ b/webserver/index.js
@@ -213,12 +213,12 @@ app.post("/deletePermission", checkForInit, async (req, res) => {
 app.post("/deletePermissions", checkForInit, async (req, res) => {
   if (req.isAuthenticated() && req.user && req.user.accessToken) {
     try {
-      const { fileIds } = req.body;
+      const { fileIds, permissionIds, emails } = req.body;
       setOauth2ClientCredentials(req.user.accessToken, req.user.refreshToken);
       const client = new DrivePermissionManager(oauth2Client);
       try {
         // returns an array of all updated files
-        let files = await client.deletePermissions(fileIds);
+        let files = await client.deletePermissions(fileIds, {permissionIds,emails});
         res.json(files);
       }
       catch (error) {


### PR DESCRIPTION
Closes #368 #369

Route change was fairly straightforward. Client-side may send an array of permissions ids or email addresses in the request body. Both will achieve the same thing.